### PR TITLE
Fix Docker image tag to be lowercase

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,4 +27,4 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          tags: xianwei2022/linAcc:latest
+          tags: xianwei2022/linacc:latest


### PR DESCRIPTION
## Summary
- fix tag in Docker GitHub workflow to use lowercase name

## Testing
- `go test ./...` *(fails: missing go.sum entry)*
- `go vet ./...` *(fails: missing go.sum entry)*

------
https://chatgpt.com/codex/tasks/task_b_68593185d6048326b22ec5c907bd652f